### PR TITLE
Fix header sanitization for multi-row headers

### DIFF
--- a/src/Keboola/GoogleDriveExtractor/Extractor/Output.php
+++ b/src/Keboola/GoogleDriveExtractor/Extractor/Output.php
@@ -78,8 +78,8 @@ class Output
         }
 
         foreach ($data as $k => $row) {
-            // Skip header row if rows > 0 and it's the header row
-            if ($this->sheetCfg['header']['rows'] > 0 && $k === 0 && $offset === 1) {
+            // backward compatibility fix - only sanitize header when there's exactly 1 header row
+            if ($this->sheetCfg['header']['rows'] === 1 && $k === 0 && $offset === 1) {
                 if (!isset($this->sheetCfg['header']['sanitize']) || $this->sheetCfg['header']['sanitize'] !== false) {
                     $row = $this->normalizeCsvHeader($row);
                 }


### PR DESCRIPTION
## Summary

- Fixes a regression introduced in PR #15 where date values like `01/2026` were being corrupted to `012026`
- The condition for header sanitization was incorrectly changed from `=== 1` to `> 0`
- This caused the first row to be sanitized even when multiple header rows were configured (`header.rows > 1`)
- The `Utility::sanitize()` function strips non-alphanumeric characters (including `/`), which was never intended to be applied to data rows

## Root Cause

In `Output.php`, the condition:
```php
if ($this->sheetCfg['header']['rows'] === 1 && $k === 0 && $offset === 1)
```
was changed to:
```php
if ($this->sheetCfg['header']['rows'] > 0 && $k === 0 && $offset === 1)
```

This meant that for configurations with `header.rows = 2`, the first row was incorrectly sanitized.

## Fix

Reverted the condition back to `=== 1` to restore the original behavior.