### PR TITLE
Add support for flexible range extraction with row boundaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ composer.phar
 tests.sh
 tokens.php
 run.sh
+.claude

--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ parameters:
       sheetTitle: SHEET_TITLE
       outputTable: FILE_TITLE
       enabled: true
-      columnRange: "Z:AE"  # Optional: limit extraction to specific columns
+      columnRange: "A:E"   # Optional: Specify range to extract
+                           # Formats: "A:E" (all rows), "A1:E10" (bounded), "A10:E" (from row 10), "A:E10" (rows 1-10)
       header:
-        rows: 0            # Set to 0 for no header (generates column letters: Z, AA, AB, AC, AD, AE)
+        rows: 0            # Set to 0 for no header (generates column letters)
 ```
 
 ## OAuth Registration

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3,345 +3,365 @@ parameters:
 		-
 			message: "#^Cannot access offset 'access_token' on mixed\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/Application.php
+			path: src/Keboola/GoogleDriveExtractor/Application.php
 
 		-
 			message: "#^Cannot access offset 'refresh_token' on mixed\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/Application.php
+			path: src/Keboola/GoogleDriveExtractor/Application.php
 
 		-
 			message: "#^Cannot access offset 'sheets' on mixed\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/Application.php
+			path: src/Keboola/GoogleDriveExtractor/Application.php
 
 		-
 			message: "#^Cannot call method warning\\(\\) on mixed\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/Application.php
+			path: src/Keboola/GoogleDriveExtractor/Application.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\Application\\:\\:__construct\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/Application.php
+			path: src/Keboola/GoogleDriveExtractor/Application.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\Application\\:\\:run\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/Application.php
+			path: src/Keboola/GoogleDriveExtractor/Application.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\Application\\:\\:runAction\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/Application.php
+			path: src/Keboola/GoogleDriveExtractor/Application.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\Application\\:\\:validateParameters\\(\\) has parameter \\$parameters with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/Application.php
+			path: src/Keboola/GoogleDriveExtractor/Application.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\Application\\:\\:validateParameters\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/Application.php
+			path: src/Keboola/GoogleDriveExtractor/Application.php
 
 		-
 			message: "#^Parameter \\#1 \\$sheets of method Keboola\\\\GoogleDriveExtractor\\\\Extractor\\\\Extractor\\:\\:run\\(\\) expects array, mixed given\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/Application.php
+			path: src/Keboola/GoogleDriveExtractor/Application.php
 
 		-
 			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/Application.php
+			path: src/Keboola/GoogleDriveExtractor/Application.php
 
 		-
 			message: "#^Parameter \\#3 \\$accessToken of static method Keboola\\\\Google\\\\ClientBundle\\\\Google\\\\RestApi\\:\\:createWithOAuth\\(\\) expects string, mixed given\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/Application.php
+			path: src/Keboola/GoogleDriveExtractor/Application.php
 
 		-
 			message: "#^Parameter \\#4 \\$refreshToken of static method Keboola\\\\Google\\\\ClientBundle\\\\Google\\\\RestApi\\:\\:createWithOAuth\\(\\) expects string, mixed given\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/Application.php
+			path: src/Keboola/GoogleDriveExtractor/Application.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\Exception\\\\ApplicationException\\:\\:__construct\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/Exception/ApplicationException.php
+			path: src/Keboola/GoogleDriveExtractor/Exception/ApplicationException.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\Exception\\\\ApplicationException\\:\\:getData\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/Exception/ApplicationException.php
+			path: src/Keboola/GoogleDriveExtractor/Exception/ApplicationException.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\Exception\\\\ApplicationException\\:\\:setData\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/Exception/ApplicationException.php
+			path: src/Keboola/GoogleDriveExtractor/Exception/ApplicationException.php
 
 		-
 			message: "#^Property Keboola\\\\GoogleDriveExtractor\\\\Exception\\\\ApplicationException\\:\\:\\$data type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/Exception/ApplicationException.php
+			path: src/Keboola/GoogleDriveExtractor/Exception/ApplicationException.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\Extractor\\\\ExceptionHandler\\:\\:handleExportException\\(\\) has parameter \\$sheet with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/Extractor/ExceptionHandler.php
+			path: src/Keboola/GoogleDriveExtractor/Extractor/ExceptionHandler.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\Extractor\\\\ExceptionHandler\\:\\:handleGetSpreadsheetException\\(\\) has parameter \\$sheet with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/Extractor/ExceptionHandler.php
+			path: src/Keboola/GoogleDriveExtractor/Extractor/ExceptionHandler.php
 
 		-
 			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, mixed given\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/Extractor/ExceptionHandler.php
+			path: src/Keboola/GoogleDriveExtractor/Extractor/ExceptionHandler.php
+
+		-
+			message: "#^Cannot access offset 'title' on mixed\\.$#"
+			count: 2
+			path: src/Keboola/GoogleDriveExtractor/Extractor/Extractor.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\Extractor\\\\Extractor\\:\\:export\\(\\) has parameter \\$sheetCfg with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/Extractor/Extractor.php
+			path: src/Keboola/GoogleDriveExtractor/Extractor/Extractor.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\Extractor\\\\Extractor\\:\\:export\\(\\) has parameter \\$spreadsheet with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/Extractor/Extractor.php
+			path: src/Keboola/GoogleDriveExtractor/Extractor/Extractor.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\Extractor\\\\Extractor\\:\\:getSheetById\\(\\) has parameter \\$sheets with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/Extractor/Extractor.php
+			path: src/Keboola/GoogleDriveExtractor/Extractor/Extractor.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\Extractor\\\\Extractor\\:\\:getSheetById\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/Extractor/Extractor.php
-
-		-
-			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\Extractor\\\\Extractor\\:\\:parseColumnRange\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/Extractor/Extractor.php
+			path: src/Keboola/GoogleDriveExtractor/Extractor/Extractor.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\Extractor\\\\Extractor\\:\\:run\\(\\) has parameter \\$sheets with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/Extractor/Extractor.php
+			path: src/Keboola/GoogleDriveExtractor/Extractor/Extractor.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\Extractor\\\\Extractor\\:\\:run\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/Extractor/Extractor.php
+			path: src/Keboola/GoogleDriveExtractor/Extractor/Extractor.php
+
+		-
+			message: "#^Parameter \\#1 \\$sheetTitle of method Keboola\\\\GoogleDriveExtractor\\\\Extractor\\\\Extractor\\:\\:getBoundedRange\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Keboola/GoogleDriveExtractor/Extractor/Extractor.php
+
+		-
+			message: "#^Parameter \\#1 \\$sheetTitle of method Keboola\\\\GoogleDriveExtractor\\\\Extractor\\\\Extractor\\:\\:getRange\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Keboola/GoogleDriveExtractor/Extractor/Extractor.php
+
+		-
+			message: "#^Parameter \\#1 \\$spreadsheetId of method Keboola\\\\GoogleDriveExtractor\\\\GoogleDrive\\\\Client\\:\\:getSpreadsheetValues\\(\\) expects string, mixed given\\.$#"
+			count: 2
+			path: src/Keboola/GoogleDriveExtractor/Extractor/Extractor.php
+
+		-
+			message: "#^Parameter \\#2 \\$outputTable of method Keboola\\\\GoogleDriveExtractor\\\\Extractor\\\\Output\\:\\:createManifest\\(\\) expects string, mixed given\\.$#"
+			count: 2
+			path: src/Keboola/GoogleDriveExtractor/Extractor/Extractor.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\Extractor\\\\Output\\:\\:createCsv\\(\\) has parameter \\$sheet with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/Extractor/Output.php
+			path: src/Keboola/GoogleDriveExtractor/Extractor/Output.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\Extractor\\\\Output\\:\\:getHeaderLength\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/Extractor/Output.php
+			path: src/Keboola/GoogleDriveExtractor/Extractor/Output.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\Extractor\\\\Output\\:\\:normalizeCsvHeader\\(\\) has parameter \\$header with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/Extractor/Output.php
+			path: src/Keboola/GoogleDriveExtractor/Extractor/Output.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\Extractor\\\\Output\\:\\:normalizeCsvHeader\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/Extractor/Output.php
+			path: src/Keboola/GoogleDriveExtractor/Extractor/Output.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\Extractor\\\\Output\\:\\:write\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/Extractor/Output.php
+			path: src/Keboola/GoogleDriveExtractor/Extractor/Output.php
 
 		-
 			message: "#^Property Keboola\\\\GoogleDriveExtractor\\\\Extractor\\\\Output\\:\\:\\$header type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/Extractor/Output.php
+			path: src/Keboola/GoogleDriveExtractor/Extractor/Output.php
 
 		-
 			message: "#^Property Keboola\\\\GoogleDriveExtractor\\\\Extractor\\\\Output\\:\\:\\$sheetCfg type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/Extractor/Output.php
+			path: src/Keboola/GoogleDriveExtractor/Extractor/Output.php
 
 		-
 			message: "#^Cannot access offset 'id' on mixed\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/GoogleDrive/Client.php
+			path: src/Keboola/GoogleDriveExtractor/GoogleDrive/Client.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\GoogleDrive\\\\Client\\:\\:addFields\\(\\) has parameter \\$fields with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/GoogleDrive/Client.php
+			path: src/Keboola/GoogleDriveExtractor/GoogleDrive/Client.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\GoogleDrive\\\\Client\\:\\:createFile\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/GoogleDrive/Client.php
+			path: src/Keboola/GoogleDriveExtractor/GoogleDrive/Client.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\GoogleDrive\\\\Client\\:\\:createFile\\(\\) should return array but returns mixed\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/GoogleDrive/Client.php
+			path: src/Keboola/GoogleDriveExtractor/GoogleDrive/Client.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\GoogleDrive\\\\Client\\:\\:getFile\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/GoogleDrive/Client.php
+			path: src/Keboola/GoogleDriveExtractor/GoogleDrive/Client.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\GoogleDrive\\\\Client\\:\\:getFile\\(\\) should return array but returns mixed\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/GoogleDrive/Client.php
+			path: src/Keboola/GoogleDriveExtractor/GoogleDrive/Client.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\GoogleDrive\\\\Client\\:\\:getSpreadsheet\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/GoogleDrive/Client.php
+			path: src/Keboola/GoogleDriveExtractor/GoogleDrive/Client.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\GoogleDrive\\\\Client\\:\\:getSpreadsheet\\(\\) should return array but returns mixed\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/GoogleDrive/Client.php
+			path: src/Keboola/GoogleDriveExtractor/GoogleDrive/Client.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\GoogleDrive\\\\Client\\:\\:getSpreadsheetValues\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/GoogleDrive/Client.php
+			path: src/Keboola/GoogleDriveExtractor/GoogleDrive/Client.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\GoogleDrive\\\\Client\\:\\:getSpreadsheetValues\\(\\) should return array but returns mixed\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/GoogleDrive/Client.php
+			path: src/Keboola/GoogleDriveExtractor/GoogleDrive/Client.php
 
 		-
 			message: "#^Parameter \\#3 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
 			count: 1
-			path: /code/src/Keboola/GoogleDriveExtractor/GoogleDrive/Client.php
+			path: src/Keboola/GoogleDriveExtractor/GoogleDrive/Client.php
 
 		-
 			message: "#^Cannot access offset 'destination' on mixed\\.$#"
 			count: 1
-			path: /code/tests/ApplicationTest.php
+			path: tests/ApplicationTest.php
 
 		-
 			message: "#^Cannot access offset 'incremental' on mixed\\.$#"
 			count: 1
-			path: /code/tests/ApplicationTest.php
+			path: tests/ApplicationTest.php
 
 		-
 			message: "#^Parameter \\#2 \\$array of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayHasKey\\(\\) expects array\\|ArrayAccess, mixed given\\.$#"
 			count: 2
-			path: /code/tests/ApplicationTest.php
+			path: tests/ApplicationTest.php
 
 		-
 			message: "#^Cannot access offset '\\#serviceAccount' on mixed\\.$#"
 			count: 1
-			path: /code/tests/BaseTest.php
+			path: tests/BaseTest.php
 
 		-
 			message: "#^Cannot access offset 'authorization' on mixed\\.$#"
 			count: 2
-			path: /code/tests/BaseTest.php
+			path: tests/BaseTest.php
 
 		-
 			message: "#^Cannot access offset 'credentials' on mixed\\.$#"
 			count: 1
-			path: /code/tests/BaseTest.php
+			path: tests/BaseTest.php
 
 		-
 			message: "#^Cannot access offset 'data_dir' on mixed\\.$#"
 			count: 2
-			path: /code/tests/BaseTest.php
+			path: tests/BaseTest.php
 
 		-
 			message: "#^Cannot access offset 'oauth_api' on mixed\\.$#"
 			count: 1
-			path: /code/tests/BaseTest.php
+			path: tests/BaseTest.php
 
 		-
 			message: "#^Cannot access offset 'parameters' on mixed\\.$#"
 			count: 5
-			path: /code/tests/BaseTest.php
+			path: tests/BaseTest.php
 
 		-
 			message: "#^Cannot access offset 'sheets' on mixed\\.$#"
 			count: 2
-			path: /code/tests/BaseTest.php
+			path: tests/BaseTest.php
 
 		-
 			message: "#^Cannot access offset 0 on mixed\\.$#"
 			count: 2
-			path: /code/tests/BaseTest.php
+			path: tests/BaseTest.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\Tests\\\\BaseTest\\:\\:makeConfig\\(\\) has parameter \\$testFile with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/tests/BaseTest.php
+			path: tests/BaseTest.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\Tests\\\\BaseTest\\:\\:makeConfig\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/tests/BaseTest.php
+			path: tests/BaseTest.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\Tests\\\\BaseTest\\:\\:makeConfig\\(\\) should return array but returns mixed\\.$#"
 			count: 1
-			path: /code/tests/BaseTest.php
+			path: tests/BaseTest.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\Tests\\\\BaseTest\\:\\:makeConfigWithServiceAccount\\(\\) has parameter \\$testFile with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/tests/BaseTest.php
+			path: tests/BaseTest.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\Tests\\\\BaseTest\\:\\:makeConfigWithServiceAccount\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/tests/BaseTest.php
+			path: tests/BaseTest.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\Tests\\\\BaseTest\\:\\:makeConfigWithServiceAccount\\(\\) should return array but returns mixed\\.$#"
 			count: 1
-			path: /code/tests/BaseTest.php
+			path: tests/BaseTest.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\Tests\\\\BaseTest\\:\\:prepareTestFile\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/tests/BaseTest.php
+			path: tests/BaseTest.php
 
 		-
 			message: "#^Property Keboola\\\\GoogleDriveExtractor\\\\Tests\\\\BaseTest\\:\\:\\$config type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/tests/BaseTest.php
+			path: tests/BaseTest.php
 
 		-
 			message: "#^Property Keboola\\\\GoogleDriveExtractor\\\\Tests\\\\BaseTest\\:\\:\\$testFile type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/tests/BaseTest.php
+			path: tests/BaseTest.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\Tests\\\\Extractor\\\\ExceptionHandleTest\\:\\:provideExceptionsForExport\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/tests/Extractor/ExceptionHandleTest.php
+			path: tests/Extractor/ExceptionHandleTest.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\Tests\\\\Extractor\\\\ExceptionHandleTest\\:\\:provideExceptionsForGetSpreadsheet\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/tests/Extractor/ExceptionHandleTest.php
+			path: tests/Extractor/ExceptionHandleTest.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\Tests\\\\Extractor\\\\ExceptionHandleTest\\:\\:testExportExceptionHandling\\(\\) has parameter \\$sheet with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/tests/Extractor/ExceptionHandleTest.php
+			path: tests/Extractor/ExceptionHandleTest.php
 
 		-
 			message: "#^Method Keboola\\\\GoogleDriveExtractor\\\\Tests\\\\Extractor\\\\ExceptionHandleTest\\:\\:testHandlingOfExceptions\\(\\) has parameter \\$sheet with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: /code/tests/Extractor/ExceptionHandleTest.php
+			path: tests/Extractor/ExceptionHandleTest.php
 

--- a/src/Keboola/GoogleDriveExtractor/Configuration/ConfigDefinition.php
+++ b/src/Keboola/GoogleDriveExtractor/Configuration/ConfigDefinition.php
@@ -62,9 +62,12 @@ class ConfigDefinition implements ConfigurationInterface
                                         if ($v === '') {
                                             return false;
                                         }
-                                        return !preg_match('/^[A-Z]+:[A-Z]+$/', $v);
+                                        return !preg_match('/^[A-Z]+(\d+)?:[A-Z]+(\d+)?$/i', $v);
                                     })
-                                    ->thenInvalid('Column range must be in format "A:E" (letter:letter)')
+                                    ->thenInvalid(
+                                        'Column range must be in format "A:E" (columns), ' .
+                                        '"A1:E10" (bounded), "A10:E" (start row), or "A:E10" (end row)',
+                                    )
                                 ->end()
                             ->end()
                             ->arrayNode('header')

--- a/src/Keboola/GoogleDriveExtractor/Extractor/Extractor.php
+++ b/src/Keboola/GoogleDriveExtractor/Extractor/Extractor.php
@@ -83,27 +83,132 @@ class Extractor
     private function export(array $spreadsheet, array $sheetCfg): void
     {
         $sheet = $this->getSheetById($spreadsheet['sheets'], (string) $sheetCfg['sheetId']);
-        $rowCount = $sheet['properties']['gridProperties']['rowCount'];
-        $columnCount = $sheet['properties']['gridProperties']['columnCount'];
-        $offset = 1;
-        $limit = 1000;
+        $sheetRowCount = $sheet['properties']['gridProperties']['rowCount'];
+        $sheetColumnCount = $sheet['properties']['gridProperties']['columnCount'];
 
-        // Parse and validate column range if specified
+        // Parse range if specified
         $startColumn = 1;
-        $endColumn = $columnCount;
+        $endColumn = $sheetColumnCount;
+        $startRow = 1;
+        $endRow = null; // null = unbounded (paginate)
+
         if (!empty($sheetCfg['columnRange'])) {
-            [$startColumn, $endColumn] = $this->parseColumnRange(
+            [$startColumn, $endColumn, $startRow, $endRow] = $this->parseRange(
                 $sheetCfg['columnRange'],
-                $columnCount,
+                $sheetRowCount,
+                $sheetColumnCount,
                 $sheet['properties']['title'],
             );
         }
 
-        while ($offset <= $rowCount) {
-            $this->logger->info(sprintf('Extracting rows %s to %s', $offset, $offset+$limit));
+        // Branch based on range type
+        if ($endRow !== null) {
+            // Bounded range: single API call
+            $this->exportBoundedRange(
+                $spreadsheet,
+                $sheet,
+                $sheetCfg,
+                $startColumn,
+                $endColumn,
+                $startRow,
+                $endRow,
+            );
+        } else {
+            // Unbounded range: pagination from startRow to end
+            $this->exportUnboundedRange(
+                $spreadsheet,
+                $sheet,
+                $sheetCfg,
+                $startColumn,
+                $endColumn,
+                $startRow,
+                $sheetRowCount,
+            );
+        }
+    }
+
+    /**
+     * Export a bounded range (e.g., A1:E10) with a single API call
+     *
+     * @param array<mixed> $spreadsheet
+     * @param array<mixed> $sheet
+     * @param array<mixed> $sheetCfg
+     */
+    private function exportBoundedRange(
+        array $spreadsheet,
+        array $sheet,
+        array $sheetCfg,
+        int $startColumn,
+        int $endColumn,
+        int $startRow,
+        int $endRow,
+    ): void {
+        $this->logger->info(sprintf(
+            'Extracting bounded range: columns %s-%s, rows %d-%d',
+            $this->columnToLetter($startColumn),
+            $this->columnToLetter($endColumn),
+            $startRow,
+            $endRow,
+        ));
+
+        $range = $this->getBoundedRange(
+            $sheet['properties']['title'],
+            $startColumn,
+            $endColumn,
+            $startRow,
+            $endRow,
+        );
+
+        $response = $this->driveApi->getSpreadsheetValues(
+            $spreadsheet['spreadsheetId'],
+            $range,
+        );
+
+        if (!empty($response['values'])) {
+            $sheetCfgWithRange = $sheetCfg;
+            $sheetCfgWithRange['_startColumn'] = $startColumn;
+            $sheetCfgWithRange['_endColumn'] = $endColumn;
+            $sheetCfgWithRange['_startRow'] = $startRow;
+            $sheetCfgWithRange['_endRow'] = $endRow;
+
+            $csvFilename = $this->output->createCsv($sheetCfgWithRange);
+            $this->output->createManifest($csvFilename, $sheetCfg['outputTable']);
+            $this->output->write($response['values'], $startRow);
+        }
+    }
+
+    /**
+     * Export an unbounded range (e.g., A:E or A10:E) with pagination
+     *
+     * @param array<mixed> $spreadsheet
+     * @param array<mixed> $sheet
+     * @param array<mixed> $sheetCfg
+     */
+    private function exportUnboundedRange(
+        array $spreadsheet,
+        array $sheet,
+        array $sheetCfg,
+        int $startColumn,
+        int $endColumn,
+        int $startRow,
+        int $sheetRowCount,
+    ): void {
+        $offset = $startRow;
+        $limit = 1000;
+        $firstBatch = true;
+
+        while ($offset <= $sheetRowCount) {
+            $this->logger->info(sprintf(
+                'Extracting rows %d to %d (columns %s-%s)',
+                $offset,
+                min($offset + $limit - 1, $sheetRowCount),
+                $this->columnToLetter($startColumn),
+                $this->columnToLetter($endColumn),
+            ));
+
             $range = $this->getRange(
                 $sheet['properties']['title'],
-                $columnCount,
+                $sheetRowCount,
                 $offset,
                 $limit,
                 $startColumn,
@@ -116,14 +221,16 @@ class Extractor
             );
 
             if (!empty($response['values'])) {
-                if ($offset === 1) {
-                    // it is a first run
-                    // Pass column range info to output for header generation
+                if ($firstBatch) {
                     $sheetCfgWithRange = $sheetCfg;
                     $sheetCfgWithRange['_startColumn'] = $startColumn;
                     $sheetCfgWithRange['_endColumn'] = $endColumn;
+                    $sheetCfgWithRange['_startRow'] = $startRow;
+                    $sheetCfgWithRange['_endRow'] = null;
+
                     $csvFilename = $this->output->createCsv($sheetCfgWithRange);
                     $this->output->createManifest($csvFilename, $sheetCfg['outputTable']);
+                    $firstBatch = false;
                 }
 
                 $this->output->write($response['values'], $offset);
@@ -161,6 +268,25 @@ class Extractor
         return urlencode($sheetTitle) . '!' . $start . ':' . $end;
     }
 
+    /**
+     * Build API range string for bounded ranges (e.g., "Sheet1!A1:E10")
+     */
+    private function getBoundedRange(
+        string $sheetTitle,
+        int $startColumn,
+        int $endColumn,
+        int $startRow,
+        int $endRow,
+    ): string {
+        $firstColumn = $this->columnToLetter($startColumn);
+        $lastColumn = $this->columnToLetter($endColumn);
+
+        $start = $firstColumn . $startRow;
+        $end = $lastColumn . $endRow;
+
+        return urlencode($sheetTitle) . '!' . $start . ':' . $end;
+    }
+
     public function columnToLetter(int $column): string
     {
         $alphas = range('A', 'Z');
@@ -188,60 +314,108 @@ class Extractor
     }
 
     /**
-     * Parse column range string (e.g., "A:E") and validate against sheet column count
+     * Parse a cell reference like "A10" into [column, row]
      *
-     * @param string $columnRange Column range in format "A:E"
-     * @param int $sheetColumnCount Total number of columns in the sheet
-     * @param string $sheetTitle Sheet title for error messages
-     * @return array [startColumn, endColumn] as numeric indices (1-based)
-     * @throws UserException if range is invalid
+     * @param string $cell Cell reference (e.g., "A10", "AA", "Z100")
+     * @return array{int, int|null} [column: int, row: int|null] 1-based indices
      */
-    private function parseColumnRange(string $columnRange, int $sheetColumnCount, string $sheetTitle): array
+    private function parseCell(string $cell): array
     {
-        $parts = explode(':', $columnRange);
+        if (!preg_match('/^([A-Z]+)(\d*)$/i', $cell, $matches)) {
+            throw new UserException(sprintf('Invalid cell reference: "%s"', $cell));
+        }
+
+        $letter = strtoupper($matches[1]);
+        $row = $matches[2] !== '' ? (int) $matches[2] : null;
+
+        $column = $this->letterToColumn($letter);
+
+        return [$column, $row];
+    }
+
+    /**
+     * Parse range string and validate against sheet dimensions
+     *
+     * Supports: "A:E", "A1:E10", "A10:E", "A:E10"
+     *
+     * @param string $range Range string
+     * @param int $sheetRowCount Total rows in sheet
+     * @param int $sheetColumnCount Total columns in sheet
+     * @param string $sheetTitle Sheet title for error messages
+     * @return array{int, int, int, int|null} [startColumn, endColumn, startRow, endRow|null] 1-based indices
+     */
+    private function parseRange(
+        string $range,
+        int $sheetRowCount,
+        int $sheetColumnCount,
+        string $sheetTitle,
+    ): array {
+        $parts = explode(':', $range);
         if (count($parts) !== 2) {
             throw new UserException(sprintf(
-                'Invalid column range "%s" for sheet "%s". Expected format: "A:E"',
-                $columnRange,
+                'Invalid range "%s" for sheet "%s". Expected format: "A:E", "A1:E10", "A10:E", or "A:E10"',
+                $range,
                 $sheetTitle,
             ));
         }
 
-        $startColumn = $this->letterToColumn($parts[0]);
-        $endColumn = $this->letterToColumn($parts[1]);
+        // Parse start and end cells
+        [$startColumn, $startRow] = $this->parseCell($parts[0]);
+        [$endColumn, $endRow] = $this->parseCell($parts[1]);
 
+        // Validate column order
         if ($startColumn > $endColumn) {
             throw new UserException(sprintf(
-                'Invalid column range "%s" for sheet "%s": start column "%s" must be before or equal to ' .
-                'end column "%s"',
-                $columnRange,
+                'Invalid range "%s" for sheet "%s": start column "%s" must be ≤ end column "%s"',
+                $range,
                 $sheetTitle,
                 $parts[0],
                 $parts[1],
             ));
         }
 
-        if ($startColumn < 1) {
+        // Validate row order (if both specified)
+        if ($startRow !== null && $endRow !== null && $startRow > $endRow) {
             throw new UserException(sprintf(
-                'Invalid column range "%s" for sheet "%s": start column must be at least "A"',
-                $columnRange,
+                'Invalid range "%s" for sheet "%s": start row %d must be ≤ end row %d',
+                $range,
+                $sheetTitle,
+                $startRow,
+                $endRow,
+            ));
+        }
+
+        // Validate minimum bounds
+        if ($startColumn < 1 || $endColumn < 1 ||
+            ($startRow !== null && $startRow < 1) ||
+            ($endRow !== null && $endRow < 1)) {
+            throw new UserException(sprintf(
+                'Invalid range "%s" for sheet "%s": columns must be ≥ A, rows must be ≥ 1',
+                $range,
                 $sheetTitle,
             ));
         }
 
-        if ($endColumn > $sheetColumnCount) {
-            throw new UserException(sprintf(
-                'Column range "%s" exceeds sheet dimensions for sheet "%s". ' .
-                'Sheet has %d columns (A-%s), but range requests up to column %s',
-                $columnRange,
+        // Cap to sheet boundaries (silent capping per user requirement)
+        $cappedStartColumn = max(1, min($startColumn, $sheetColumnCount));
+        $cappedEndColumn = max(1, min($endColumn, $sheetColumnCount));
+        $cappedStartRow = $startRow !== null ? max(1, min($startRow, $sheetRowCount)) : 1;
+        $cappedEndRow = $endRow !== null ? max(1, min($endRow, $sheetRowCount)) : null;
+
+        // Log warning if capping occurred
+        if ($cappedStartColumn !== $startColumn || $cappedEndColumn !== $endColumn ||
+            ($startRow !== null && $cappedStartRow !== $startRow) ||
+            ($endRow !== null && $cappedEndRow !== $endRow)) {
+            $this->logger->warning(sprintf(
+                'Range "%s" for sheet "%s" exceeded boundaries (rows: %d, cols: %d). Capped to available data.',
+                $range,
                 $sheetTitle,
+                $sheetRowCount,
                 $sheetColumnCount,
-                $this->columnToLetter($sheetColumnCount),
-                $parts[1],
             ));
         }
 
-        return [$startColumn, $endColumn];
+        return [$cappedStartColumn, $cappedEndColumn, $cappedStartRow, $cappedEndRow];
     }
 
     public function refreshTokenCallback(string $accessToken, string $refreshToken): void

--- a/src/Keboola/GoogleDriveExtractor/Extractor/Output.php
+++ b/src/Keboola/GoogleDriveExtractor/Extractor/Output.php
@@ -64,7 +64,8 @@ class Output
                 }
                 $headerLength = $columnCount;
                 // Write the generated header as first row
-                if ($offset === 1) {
+                $startRow = $this->sheetCfg['_startRow'] ?? 1;
+                if ($offset === $startRow) {
                     $this->csv->writeRow($this->header);
                 }
             } else {
@@ -79,7 +80,8 @@ class Output
 
         foreach ($data as $k => $row) {
             // backward compatibility fix - only sanitize header when there's exactly 1 header row
-            if ($this->sheetCfg['header']['rows'] === 1 && $k === 0 && $offset === 1) {
+            $startRow = $this->sheetCfg['_startRow'] ?? 1;
+            if ($this->sheetCfg['header']['rows'] === 1 && $k === 0 && $offset === $startRow) {
                 if (!isset($this->sheetCfg['header']['sanitize']) || $this->sheetCfg['header']['sanitize'] !== false) {
                     $row = $this->normalizeCsvHeader($row);
                 }

--- a/tests/Extractor/ConfigDefinitionTest.php
+++ b/tests/Extractor/ConfigDefinitionTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\GoogleDriveExtractor\Tests\Extractor;
+
+use Generator;
+use Keboola\GoogleDriveExtractor\Configuration\ConfigDefinition;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Config\Definition\Processor;
+
+class ConfigDefinitionTest extends TestCase
+{
+    /** @dataProvider validColumnRangeProvider */
+    public function testColumnRangeValidation(string $columnRange): void
+    {
+        $processor = new Processor();
+        $definition = new ConfigDefinition();
+
+        $config = [
+            'data_dir' => '/data',
+            'sheets' => [
+                [
+                    'id' => 0,
+                    'fileId' => 'test-file-id',
+                    'fileTitle' => 'Test File',
+                    'sheetId' => '0',
+                    'sheetTitle' => 'Sheet1',
+                    'outputTable' => 'test-table',
+                    'enabled' => true,
+                    'columnRange' => $columnRange,
+                ],
+            ],
+        ];
+
+        $processedConfig = $processor->processConfiguration($definition, [$config]);
+
+        $this->assertEquals($columnRange, $processedConfig['sheets'][0]['columnRange']);
+    }
+
+    public function validColumnRangeProvider(): Generator
+    {
+        yield 'column-only' => ['A:E'];
+        yield 'bounded' => ['A1:E10'];
+        yield 'partial-start' => ['A10:E'];
+        yield 'partial-end' => ['A:E10'];
+        yield 'single-cell' => ['A1:A1'];
+        yield 'multi-letter-columns' => ['AA:ZZ'];
+        yield 'case-insensitive' => ['a:e'];
+        yield 'mixed-case' => ['A1:e10'];
+    }
+
+    /** @dataProvider invalidColumnRangeProvider */
+    public function testColumnRangeValidationInvalid(string $columnRange): void
+    {
+        $processor = new Processor();
+        $definition = new ConfigDefinition();
+
+        $config = [
+            'data_dir' => '/data',
+            'sheets' => [
+                [
+                    'id' => 0,
+                    'fileId' => 'test-file-id',
+                    'fileTitle' => 'Test File',
+                    'sheetId' => '0',
+                    'sheetTitle' => 'Sheet1',
+                    'outputTable' => 'test-table',
+                    'enabled' => true,
+                    'columnRange' => $columnRange,
+                ],
+            ],
+        ];
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessageMatches('/Column range must be in format/');
+
+        $processor->processConfiguration($definition, [$config]);
+    }
+
+    public function invalidColumnRangeProvider(): Generator
+    {
+        yield 'row-only' => ['1:100'];
+        yield 'single-column' => ['A'];
+        yield 'single-cell-no-colon' => ['A1'];
+        yield 'no-letters' => ['1:2'];
+        yield 'invalid-format' => ['A-E'];
+        yield 'multiple-colons' => ['A:B:C'];
+        yield 'missing-colon' => ['A1E10'];
+        yield 'special-chars' => ['A@:E#'];
+        yield 'with-spaces' => ['A 1:E 10'];
+        yield 'empty-start' => [':E10'];
+        yield 'empty-end' => ['A1:'];
+    }
+
+    public function testEmptyColumnRangeAllowed(): void
+    {
+        $processor = new Processor();
+        $definition = new ConfigDefinition();
+
+        $config = [
+            'data_dir' => '/data',
+            'sheets' => [
+                [
+                    'id' => 0,
+                    'fileId' => 'test-file-id',
+                    'fileTitle' => 'Test File',
+                    'sheetId' => '0',
+                    'sheetTitle' => 'Sheet1',
+                    'outputTable' => 'test-table',
+                    'enabled' => true,
+                    'columnRange' => '',
+                ],
+            ],
+        ];
+
+        $processedConfig = $processor->processConfiguration($definition, [$config]);
+
+        $this->assertEquals('', $processedConfig['sheets'][0]['columnRange']);
+    }
+}

--- a/tests/Extractor/ExtractorTest.php
+++ b/tests/Extractor/ExtractorTest.php
@@ -94,4 +94,269 @@ class ExtractorTest extends TestCase
         $range = $this->extractor->getRange('My Sheet #1', 10, 1, 1000, 1, 5);
         $this->assertEquals('My+Sheet+%231!A1:E1000', $range);
     }
+
+    public function testParseCell(): void
+    {
+        $reflection = new \ReflectionClass($this->extractor);
+        $method = $reflection->getMethod('parseCell');
+        $method->setAccessible(true);
+
+        // Test column only
+        $result = $method->invoke($this->extractor, 'A');
+        $this->assertEquals([1, null], $result);
+
+        // Test column with row
+        $result = $method->invoke($this->extractor, 'A10');
+        $this->assertEquals([1, 10], $result);
+
+        // Test multi-letter column
+        $result = $method->invoke($this->extractor, 'AA100');
+        $this->assertEquals([27, 100], $result);
+
+        // Test case insensitive
+        $result = $method->invoke($this->extractor, 'ab5');
+        $this->assertEquals([28, 5], $result);
+    }
+
+    public function testParseCellInvalid(): void
+    {
+        $reflection = new \ReflectionClass($this->extractor);
+        $method = $reflection->getMethod('parseCell');
+        $method->setAccessible(true);
+
+        $this->expectException(\Keboola\GoogleDriveExtractor\Exception\UserException::class);
+        $this->expectExceptionMessage('Invalid cell reference: "123"');
+        $method->invoke($this->extractor, '123');
+    }
+
+    public function testParseRangeColumnOnly(): void
+    {
+        $reflection = new \ReflectionClass($this->extractor);
+        $method = $reflection->getMethod('parseRange');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($this->extractor, 'A:E', 1000, 26, 'Sheet1');
+        $this->assertEquals([1, 5, 1, null], $result);
+    }
+
+    public function testParseRangeBounded(): void
+    {
+        $reflection = new \ReflectionClass($this->extractor);
+        $method = $reflection->getMethod('parseRange');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($this->extractor, 'A1:E10', 1000, 26, 'Sheet1');
+        $this->assertEquals([1, 5, 1, 10], $result);
+    }
+
+    public function testParseRangePartialStart(): void
+    {
+        $reflection = new \ReflectionClass($this->extractor);
+        $method = $reflection->getMethod('parseRange');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($this->extractor, 'A10:E', 1000, 26, 'Sheet1');
+        $this->assertEquals([1, 5, 10, null], $result);
+    }
+
+    public function testParseRangePartialEnd(): void
+    {
+        $reflection = new \ReflectionClass($this->extractor);
+        $method = $reflection->getMethod('parseRange');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($this->extractor, 'A:E10', 1000, 26, 'Sheet1');
+        $this->assertEquals([1, 5, 1, 10], $result);
+    }
+
+    public function testParseRangeSingleCell(): void
+    {
+        $reflection = new \ReflectionClass($this->extractor);
+        $method = $reflection->getMethod('parseRange');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($this->extractor, 'A1:A1', 1000, 26, 'Sheet1');
+        $this->assertEquals([1, 1, 1, 1], $result);
+    }
+
+    public function testParseRangeBoundaryCapping(): void
+    {
+        $reflection = new \ReflectionClass($this->extractor);
+        $method = $reflection->getMethod('parseRange');
+        $method->setAccessible(true);
+
+        // Cap columns: Sheet has 10 columns, but range requests A:Z (26 columns)
+        $result = $method->invoke($this->extractor, 'A:Z', 1000, 10, 'Sheet1');
+        $this->assertEquals([1, 10, 1, null], $result);
+
+        // Cap rows: Sheet has 50 rows, but range requests A1:E100
+        $result = $method->invoke($this->extractor, 'A1:E100', 50, 26, 'Sheet1');
+        $this->assertEquals([1, 5, 1, 50], $result);
+
+        // Cap start row: Start row 1000, but sheet has only 100 rows
+        $result = $method->invoke($this->extractor, 'A1000:E', 100, 26, 'Sheet1');
+        $this->assertEquals([1, 5, 100, null], $result);
+    }
+
+    public function testParseRangeInvalidColumnOrder(): void
+    {
+        $reflection = new \ReflectionClass($this->extractor);
+        $method = $reflection->getMethod('parseRange');
+        $method->setAccessible(true);
+
+        $this->expectException(\Keboola\GoogleDriveExtractor\Exception\UserException::class);
+        $this->expectExceptionMessage('start column "E" must be ≤ end column "A"');
+        $method->invoke($this->extractor, 'E:A', 1000, 26, 'Sheet1');
+    }
+
+    public function testParseRangeInvalidRowOrder(): void
+    {
+        $reflection = new \ReflectionClass($this->extractor);
+        $method = $reflection->getMethod('parseRange');
+        $method->setAccessible(true);
+
+        $this->expectException(\Keboola\GoogleDriveExtractor\Exception\UserException::class);
+        $this->expectExceptionMessage('start row 20 must be ≤ end row 10');
+        $method->invoke($this->extractor, 'A20:E10', 1000, 26, 'Sheet1');
+    }
+
+    public function testGetBoundedRange(): void
+    {
+        $reflection = new \ReflectionClass($this->extractor);
+        $method = $reflection->getMethod('getBoundedRange');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($this->extractor, 'Sheet1', 1, 5, 1, 10);
+        $this->assertEquals('Sheet1!A1:E10', $result);
+
+        // Test with multi-letter columns
+        $result = $method->invoke($this->extractor, 'Sheet1', 27, 30, 5, 20);
+        $this->assertEquals('Sheet1!AA5:AD20', $result);
+
+        // Test with special characters in title
+        $result = $method->invoke($this->extractor, 'My Sheet #1', 1, 5, 1, 10);
+        $this->assertEquals('My+Sheet+%231!A1:E10', $result);
+    }
+
+    public function testParseCellEmptyString(): void
+    {
+        $reflection = new \ReflectionClass($this->extractor);
+        $method = $reflection->getMethod('parseCell');
+        $method->setAccessible(true);
+
+        $this->expectException(\Keboola\GoogleDriveExtractor\Exception\UserException::class);
+        $this->expectExceptionMessage('Invalid cell reference: ""');
+        $method->invoke($this->extractor, '');
+    }
+
+    public function testParseCellSpecialCharacters(): void
+    {
+        $reflection = new \ReflectionClass($this->extractor);
+        $method = $reflection->getMethod('parseCell');
+        $method->setAccessible(true);
+
+        $this->expectException(\Keboola\GoogleDriveExtractor\Exception\UserException::class);
+        $this->expectExceptionMessage('Invalid cell reference: "A@10"');
+        $method->invoke($this->extractor, 'A@10');
+    }
+
+    public function testParseCellWithSpaces(): void
+    {
+        $reflection = new \ReflectionClass($this->extractor);
+        $method = $reflection->getMethod('parseCell');
+        $method->setAccessible(true);
+
+        $this->expectException(\Keboola\GoogleDriveExtractor\Exception\UserException::class);
+        $this->expectExceptionMessage('Invalid cell reference: "A 10"');
+        $method->invoke($this->extractor, 'A 10');
+    }
+
+    public function testParseRangeInvalidFormat(): void
+    {
+        $reflection = new \ReflectionClass($this->extractor);
+        $method = $reflection->getMethod('parseRange');
+        $method->setAccessible(true);
+
+        $this->expectException(\Keboola\GoogleDriveExtractor\Exception\UserException::class);
+        $this->expectExceptionMessageMatches('/Expected format/');
+        $method->invoke($this->extractor, 'A-E', 1000, 26, 'Sheet1');
+    }
+
+    public function testParseRangeMultipleColons(): void
+    {
+        $reflection = new \ReflectionClass($this->extractor);
+        $method = $reflection->getMethod('parseRange');
+        $method->setAccessible(true);
+
+        $this->expectException(\Keboola\GoogleDriveExtractor\Exception\UserException::class);
+        $this->expectExceptionMessageMatches('/Expected format/');
+        $method->invoke($this->extractor, 'A:B:C', 1000, 26, 'Sheet1');
+    }
+
+    public function testParseRangeMissingColon(): void
+    {
+        $reflection = new \ReflectionClass($this->extractor);
+        $method = $reflection->getMethod('parseRange');
+        $method->setAccessible(true);
+
+        $this->expectException(\Keboola\GoogleDriveExtractor\Exception\UserException::class);
+        $this->expectExceptionMessageMatches('/Expected format/');
+        $method->invoke($this->extractor, 'A1E10', 1000, 26, 'Sheet1');
+    }
+
+    public function testParseRangeRowZero(): void
+    {
+        $reflection = new \ReflectionClass($this->extractor);
+        $method = $reflection->getMethod('parseRange');
+        $method->setAccessible(true);
+
+        $this->expectException(\Keboola\GoogleDriveExtractor\Exception\UserException::class);
+        $this->expectExceptionMessage('rows must be ≥ 1');
+        $method->invoke($this->extractor, 'A0:E10', 1000, 26, 'Sheet1');
+    }
+
+    public function testParseRangeBothBoundariesExceeded(): void
+    {
+        $reflection = new \ReflectionClass($this->extractor);
+        $method = $reflection->getMethod('parseRange');
+        $method->setAccessible(true);
+
+        // Sheet has 5 columns and 10 rows, but range requests 26 columns and 100 rows
+        $result = $method->invoke($this->extractor, 'A1:Z100', 10, 5, 'Sheet1');
+        // Should cap both: columns to 5 (A-E) and rows to 10
+        $this->assertEquals([1, 5, 1, 10], $result);
+    }
+
+    public function testParseRangeStartRowExceedsEndRow(): void
+    {
+        $reflection = new \ReflectionClass($this->extractor);
+        $method = $reflection->getMethod('parseRange');
+        $method->setAccessible(true);
+
+        $this->expectException(\Keboola\GoogleDriveExtractor\Exception\UserException::class);
+        $this->expectExceptionMessage('start row 100 must be ≤ end row 10');
+        $method->invoke($this->extractor, 'A100:E10', 1000, 26, 'Sheet1');
+    }
+
+    public function testParseRangeSameColumnAndRow(): void
+    {
+        $reflection = new \ReflectionClass($this->extractor);
+        $method = $reflection->getMethod('parseRange');
+        $method->setAccessible(true);
+
+        // Valid edge case: single cell with same column and row
+        $result = $method->invoke($this->extractor, 'B5:B5', 1000, 26, 'Sheet1');
+        $this->assertEquals([2, 2, 5, 5], $result);
+    }
+
+    public function testParseRangeVeryLargeRowNumbers(): void
+    {
+        $reflection = new \ReflectionClass($this->extractor);
+        $method = $reflection->getMethod('parseRange');
+        $method->setAccessible(true);
+
+        // Very large row numbers should be capped to sheet size
+        $result = $method->invoke($this->extractor, 'A999999:E', 1000, 26, 'Sheet1');
+        $this->assertEquals([1, 5, 1000, null], $result);
+    }
 }


### PR DESCRIPTION
Extends columnRange parameter to support bounded ranges (A1:E10), partial start (A10:E), and partial end (A:E10) formats in addition to column-only ranges (A:E). Updates validation, extraction logic, and adds comprehensive tests for all range formats.